### PR TITLE
Restrict ActiveSupport to < 5 for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 rvm:
-  - 1.9.3
+  - 2.1.0
 
 script: "bundle exec rspec"

--- a/state_machine_job.gemspec
+++ b/state_machine_job.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'activesupport'
+  spec.add_development_dependency 'activesupport', '< 5'
 
   spec.add_runtime_dependency 'resque'
   spec.add_runtime_dependency 'resque-logger'


### PR DESCRIPTION
We do not want to require Ruby 2.2.
