### PR TITLE
Use sinatra 1 in development and tests for Ruby 2.1 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in state_machine_job.gemspec
 gemspec
+
+# Sinatra 2 requires Ruby 2.2
+gem 'sinatra', '~> 1.0'


### PR DESCRIPTION
Sinatra 2 depends on Ruby 2.2. We could also just increase the Ruby version in `.travis.yml`. But I guess there is no reason to drop Ruby 2.1 support at the moment. Specifying the dependency inside the `Gemfile` instead of the `gemspec` ensures people can use the gem together with Sinatra 2 if they want.