### PR TITLE
Ensure error state can be persisted if job leaves record invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,15 @@ When the `state` attribute changes to `'running'` (either by the `run`
 event or by manually updateing the attribute), `SomeJob` will
 automatically be enqueued. If `perform_with_result` returns `:ok`, the
 state machine transitions to the `'done'` state. You can specify as
-many results as you want. Note that any exception raised by
-`perform_with_result` leads to a state machine transition as if the
-result had been `:error`. The exception is not rescued, though.
+many results as you want.
+
+Note that any exception raised by `perform_with_result` leads to a
+state machine transition as if the result had been `:error`. The
+exception is not rescued, though. If `perform_with_result` raises an
+exception and the record is invalid, previous attribute values will be
+restored before invoking the transition. That way the transition to
+the error state can be persisted by rolling back the changes that led
+to the records invalidity during job execution.
 
 ### Passing custom Payload
 

--- a/lib/state_machine_job.rb
+++ b/lib/state_machine_job.rb
@@ -9,6 +9,7 @@ module StateMachineJob
     begin
       result = perform_with_result(record, payload)
     rescue StandardError
+      record.restore_attributes unless record.valid?
       result = :error
       raise
     ensure


### PR DESCRIPTION
In cases where jobs fail with `ActiveRecord::InvalidRecord` exceptions
the transition to the error state could not be persisted since the
invalid record could not be saved. This left the record in pending
states like `processing` instead of failed states like
`processing_failed` even though an error occured.

Extend `StateMachineJob` error handling to restore previous attribute
values before invoking the error result event. This way only the state
change will be part of the update. Since exceptions rescued at this
level cannot be handled anywhere else and will only bubble up to
exception notication, changing the record this way should not be a
problem. No other code will ever interact with the record after the
state transition has been persisted.

REDMINE-16880